### PR TITLE
Refactor/cypress sad paths

### DIFF
--- a/cypress/e2e/dashboard.cy.js
+++ b/cypress/e2e/dashboard.cy.js
@@ -31,4 +31,12 @@ describe('home page', () => {
     cy.get('.beer-container').children().first().contains('h1', 'Buzz').should('not.exist')
     cy.get('.beer-container').children().first().contains('h1', 'Berliner Weisse With Yuzu - B-Sides').should('not.exist')
   })
+
+  it('should display error message if there are no search results', () => {
+    cy.visit('http://localhost:3000/')
+    .wait('@beers')
+    cy.url().should('contain', '/')
+    cy.get('#search-input').type('asdf')
+    cy.get('.beer-container').contains('h2', 'Sorry, no search results').should('be.visible')
+  })
 })

--- a/cypress/e2e/focus.cy.js
+++ b/cypress/e2e/focus.cy.js
@@ -17,6 +17,7 @@ describe('Focus page', () => {
     cy.get('.beer-container').children().first().click()
     cy.url().should('contain', '/1')
     cy.get('.single-beer-icon').should('be.visible')
+    cy.get('.search-bar').should('not.exist')
     cy.get('.single-beer-description').contains('h1', 'Buzz').should('be.visible')
     cy.get('.single-beer-description').contains('h2', 'A Real Bitter Experience.').should('be.visible')
     cy.get('.single-beer-description').contains('p', 'First Brewed: 09/2007').should('be.visible')


### PR DESCRIPTION
## What I did:
- Add cypress testing to check search functionality sad paths (no search results)
- Refactor focus spec to check that search bar is not visible on focus page
## Notes:

### Did this break anything?

- [x] No
- [ ]  Yes

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.


### What's next: